### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -3,6 +3,9 @@ name: QA
 on:
   workflow_dispatch: # Permite disparo manual se um dia você quiser descomentar
 
+permissions:
+  contents: read
+
 jobs:
   disabled:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/32](https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/32)

A correção ideal é adicionar um bloco `permissions` explícito no nível raiz do workflow (`.github/workflows/qa.yml`), para estabelecer o baseline mínimo para todos os jobs que não tenham permissões próprias. Como o job `disabled` apenas faz `echo`, o menor privilégio seguro é `contents: read`. Jobs que já possuem permissões específicas (como `publish-docker`) continuam podendo sobrescrever no nível do job sem mudança de comportamento funcional.

**Mudança específica**: inserir após o bloco `on:` (antes de `jobs:`) o trecho:

```yml
permissions:
  contents: read
```

Não são necessários imports, métodos, definições extras nem dependências.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
