### PR TITLE
Potential fix for code scanning alert no. 28: Clear-text logging of sensitive information

### DIFF
--- a/src/a4/views.py
+++ b/src/a4/views.py
@@ -100,7 +100,11 @@ def authenticate(request: HttpRequest) -> HttpResponse:
                 "Authorization": f"Bearer {access_token.get('access_token')}",
                 "x-api-key": OAUTH["CLIENT_SECRET"],
             }
-            logger.debug(f"user_info_request_header: {headers}")
+            safe_headers = {
+                "Authorization": "[REDACTED]",
+                "x-api-key": "[REDACTED]",
+            }
+            logger.debug(f"user_info_request_header: {safe_headers}")
 
             scope = access_token.get("scope", "identificacao email documentos_pessoais")
             response = _get(f"{OAUTH['USERINFO_URL']}?scope={scope}", headers=headers)


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/28](https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/28)

General fix: never log raw authentication material (tokens, API keys, client secrets, passwords). If operational visibility is needed, log only non-sensitive metadata or redact/mask sensitive keys before logging.

Best single fix here: in `src/a4/views.py`, inside `get_user_info`, replace the debug log of `headers` with a sanitized version that redacts `Authorization` and `x-api-key`. This preserves existing functionality and debug usefulness (you still see header keys and that headers were built) while removing secret disclosure. No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
