### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/src/painel/services.py
+++ b/src/painel/services.py
@@ -518,7 +518,7 @@ def get_diarios(
     ]
 
     cache.set(cache_key, results)
-    logger.debug(f"Putting cache for: {cache_key}")
+    logger.debug("Putting cache entry for get_diarios")
 
     return results
 


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/18](https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/18)

A correção mais segura e sem impacto funcional é **não registrar o `cache_key` bruto**. Em vez disso, registre uma mensagem estática (ou metadados não sensíveis, como evento de cache gravado) para manter observabilidade sem vazar dados.

Melhor ajuste pontual:
- Arquivo: `src/painel/services.py`
- Região: bloco final de `get_diarios`, na linha do `logger.debug(...)` logo após `cache.set(cache_key, results)`.
- Trocar:
  - `logger.debug(f"Putting cache for: {cache_key}")`
- Por:
  - `logger.debug("Putting cache entry for get_diarios")`

Não são necessários novos imports, métodos auxiliares ou dependências.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
