### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/src/painel/services.py
+++ b/src/painel/services.py
@@ -235,7 +235,9 @@ def requests_get(url, headers={}, encoding="utf-8", decode=True, **kwargs):
     if response.ok:
         return content
     else:
-        logger.error(f"Error fetching {url}: {response.status_code} - {response.reason}\n{content}")
+        split_url = urllib.parse.urlsplit(url)
+        safe_url = f"{split_url.scheme}://{split_url.netloc}{split_url.path}"
+        logger.error(f"Error fetching {safe_url}: {response.status_code} - {response.reason}")
         exc = HTTPException("%s - %s" % (response.status_code, response.reason))
         exc.status = response.status_code
         exc.reason = response.reason


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/16](https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/16)

A forma correta é **não registrar dados sensíveis brutos** (response body, tokens, query params).  
No trecho `requests_get` em `src/painel/services.py` (linha 238), substituir o log atual por um log sanitizado que:

- registre apenas origem segura da URL (ex.: `scheme://netloc/path`, sem query/fragment),
- mantenha `status_code` e `reason`,
- não inclua `content`.

Isso preserva a funcionalidade (continua lançando `HTTPException` e informando falha), mas elimina vazamento de dados sensíveis em texto claro.

Mudanças necessárias:
- editar somente `src/painel/services.py`, função `requests_get`;
- usar `urllib.parse.urlsplit` (já há `import urllib.parse`) para sanitizar URL sem novos imports/deps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
