### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -47,6 +47,8 @@ jobs:
 
   deploy:
     needs: publish-docker
+    permissions:
+      contents: read
     runs-on: [self-hosted, runner-dead]
     environment:
       name: production


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/34](https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/34)

Add an explicit `permissions` block to the `deploy` job to enforce least privilege.

Best fix without changing behavior:
- In `.github/workflows/build-deploy.yml`, inside `jobs.deploy`, add:
  - `permissions:`
  - `contents: read`

Why this is best:
- `actions/checkout` requires repository content read access.
- No other step in `deploy` needs extra GitHub token scopes.
- Keeps behavior intact while preventing broader default token access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
