### PR TITLE
Potential fix for code scanning alert no. 22: Information exposure through an exception

### DIFF
--- a/src/painel/api.py
+++ b/src/painel/api.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse, JsonResponse
@@ -10,6 +11,7 @@ from .brokers import SuapBroker, TokenBroker
 from .services import get_diarios, set_favourite_course, set_user_preference, set_visible_course
 
 api = NinjaAPI()
+logger = logging.getLogger(__name__)
 
 
 @api.api_operation(["GET", "OPTIONS"], "/diarios/")
@@ -109,8 +111,8 @@ def set_user_preference_endpoint(
             user.save(update_fields=["settings"])
             print(f"[OK] Preferência '{key}' atualizada localmente para {parsed_value}")
         except Exception as e:
-            print(f"[ERRO] Falha ao salvar preferência local '{key}': {e}")
-            return JsonResponse({"status": "error", "message": str(e)}, status=500)
+            logger.exception("Falha ao salvar preferência local '%s'", key)
+            return JsonResponse({"status": "error", "message": "Ocorreu um erro interno ao salvar a preferência."}, status=500)
 
         # --- Propaga para todos os ambientes Moodle ---
         from painel.models import Ambiente


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/22](https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/22)

A correção é não retornar detalhes da exceção ao cliente. Em vez disso, deve-se:
1. Registrar o erro no servidor (log), preservando contexto para depuração.
2. Retornar uma mensagem genérica ao usuário/API consumer.

Melhor ajuste sem mudar funcionalidade: no bloco `except` do trecho de atualização local, substituir o `return JsonResponse(..., "message": str(e), ...)` por uma resposta fixa e manter um log interno com traceback via `logging.exception(...)`.  
No arquivo `src/painel/api.py`:
- Adicionar `import logging` no topo.
- Criar um logger de módulo (`logger = logging.getLogger(__name__)`) próximo à inicialização da API.
- No `except Exception as e:` da região mostrada, trocar `print(...)` por `logger.exception(...)` e retornar mensagem genérica.

Isso mantém o comportamento HTTP (continua retornando erro 500 em falha), evita exposição de detalhes e melhora observabilidade no servidor.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
