### PR TITLE
Potential fix for code scanning alert no. 29: Information exposure through an exception

### DIFF
--- a/src/painel/middleware.py
+++ b/src/painel/middleware.py
@@ -104,19 +104,12 @@ class ExceptionMiddleware:
         try:
             return self.get_response(request)
         except Exception as e:
-            print("ExceptionMiddleware.__call__")
             if isinstance(e, psycopg_pool.PoolTimeout):
                 return HttpResponse("Erro de conexão com o banco!")
             if isinstance(e, psycopg.errors.Error):
                 return HttpResponse("Erro de conexão com o banco!")
-            print("ExceptionMiddleware Exception")
-            ttt = str(type(e))
-            print("ExceptionMiddleware@ttt", ttt)
-            print("ExceptionMiddleware@e", e)
-            logger.info(f"{ttt}-{e}")
-            return HttpResponse(
-                f"{ttt}-{e}, {isinstance(e, psycopg_pool.PoolTimeout)}, {isinstance(e, psycopg.errors.Error)}"
-            )
+            logger.exception("Unhandled exception in ExceptionMiddleware")
+            return HttpResponse("Erro interno do servidor!", status=500)
 
 
 class XForwardedForMiddleware(MiddlewareMixin):


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/29](https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/29)

To fix this without changing functionality, keep handling database connectivity exceptions as currently implemented, but for all other exceptions:

1. **Stop returning exception details to the client** (`ttt`, `e`, and `isinstance(...)` booleans).
2. **Log the full exception server-side** with stack trace for debugging (`logger.exception(...)`).
3. **Return a generic HTTP error message** to the client (e.g., `"Erro interno do servidor!"`) with status 500.

In `src/painel/middleware.py`, edit the `except Exception as e:` block in `ExceptionMiddleware.__call__`:
- remove debug `print` lines and the string interpolation in the response.
- replace with `logger.exception(...)` and a safe generic `HttpResponse(..., status=500)`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
