### PR TITLE
Potential fix for code scanning alert no. 17: Clear-text logging of sensitive information

### DIFF
--- a/src/painel/services.py
+++ b/src/painel/services.py
@@ -430,7 +430,7 @@ def get_diarios(
 
     results = cache.get(cache_key, None)
     if results is not None:
-        logger.debug(f"Results cache hit: {cache_key}")
+        logger.debug("Results cache hit")
         return results
 
     results = {


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/17](https://github.com/cte-zl-ifrn/integration-painel_ava/security/code-scanning/17)

A correção ideal é **não registrar o `cache_key` bruto**. Em vez disso, registrar apenas informação não sensível (por exemplo, um evento genérico de cache hit), preservando o comportamento funcional da aplicação.

Melhor abordagem sem alterar funcionalidade:
- Arquivo: `src/painel/services.py`
- Região: bloco em torno das linhas 431–434
- Alteração: substituir `logger.debug(f"Results cache hit: {cache_key}")` por uma mensagem estática (sem interpolar chave, usuário ou filtros).
- Não é necessário adicionar imports, métodos auxiliares ou dependências externas.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
